### PR TITLE
Fix Images.xcassets already exists error in manual mode

### DIFF
--- a/Assets/AppIconChanger/Editor/PostProcesser.cs
+++ b/Assets/AppIconChanger/Editor/PostProcesser.cs
@@ -89,7 +89,7 @@ namespace AppIconChanger.Editor
             {
                 if (manualTexture == null) return;
                 var path = AssetDatabase.GetAssetPath(manualTexture);
-                File.Copy(path, savePath);
+                File.Copy(path, savePath, true);
             }
         }
 


### PR DESCRIPTION
When re-building games using "Append" build mode in Unity, build fails since Images.xcassets file already exists in the build filder when icon generation mode is set to manual. Had to delete Images.xcassets file every time I build; passing 'true' as a third argument in File.Copy to overwrite any existing app icons fixed my issue.