### PR TITLE
Fill the "Alternate App Icon Sets" build settings

### DIFF
--- a/Assets/AppIconChanger/Editor/PostProcesser.cs
+++ b/Assets/AppIconChanger/Editor/PostProcesser.cs
@@ -25,10 +25,10 @@ namespace AppIconChanger.Editor
 
             var imagesXcassetsDirectoryPath = Path.Combine(pathToBuiltProject, "Unity-iPhone", "Images.xcassets");
 
-			var iconNames = new List<string>();
+            var iconNames = new List<string>();
             foreach (var alternateIcon in alternateIcons)
             {
-				iconNames.Add(alternateIcon.iconName);
+                iconNames.Add(alternateIcon.iconName);
                 var iconDirectoryPath = Path.Combine(imagesXcassetsDirectoryPath, $"{alternateIcon.iconName}.appiconset");
                 Directory.CreateDirectory(iconDirectoryPath);
 
@@ -69,12 +69,12 @@ namespace AppIconChanger.Editor
             var pbxProjectPath = Path.Combine(pathToBuiltProject, "Unity-iPhone.xcodeproj", "project.pbxproj");
             var pbxProject = new PBXProject();
             pbxProject.ReadFromFile(pbxProjectPath);
- 
+
             var targetGuid = pbxProject.GetUnityMainTargetGuid();
             pbxProject.SetBuildProperty(targetGuid, "ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS", "YES");
 
-			string joinedIconNames = string.Join(" ", iconNames);
-			pbxProject.SetBuildProperty(targetGuid, "ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES", joinedIconNames);
+            var joinedIconNames = string.Join(" ", iconNames);
+            pbxProject.SetBuildProperty(targetGuid, "ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES", joinedIconNames);
 
             pbxProject.WriteToFile(pbxProjectPath);
         }

--- a/Assets/AppIconChanger/Editor/PostProcesser.cs
+++ b/Assets/AppIconChanger/Editor/PostProcesser.cs
@@ -1,4 +1,5 @@
 ﻿#if UNITY_IOS
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -24,8 +25,10 @@ namespace AppIconChanger.Editor
 
             var imagesXcassetsDirectoryPath = Path.Combine(pathToBuiltProject, "Unity-iPhone", "Images.xcassets");
 
+			var iconNames = new List<string>();
             foreach (var alternateIcon in alternateIcons)
             {
+				iconNames.Add(alternateIcon.iconName);
                 var iconDirectoryPath = Path.Combine(imagesXcassetsDirectoryPath, $"{alternateIcon.iconName}.appiconset");
                 Directory.CreateDirectory(iconDirectoryPath);
 
@@ -66,9 +69,12 @@ namespace AppIconChanger.Editor
             var pbxProjectPath = Path.Combine(pathToBuiltProject, "Unity-iPhone.xcodeproj", "project.pbxproj");
             var pbxProject = new PBXProject();
             pbxProject.ReadFromFile(pbxProjectPath);
-
+ 
             var targetGuid = pbxProject.GetUnityMainTargetGuid();
             pbxProject.SetBuildProperty(targetGuid, "ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS", "YES");
+
+			string joinedIconNames = string.Join(" ", iconNames);
+			pbxProject.SetBuildProperty(targetGuid, "ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES", joinedIconNames);
 
             pbxProject.WriteToFile(pbxProjectPath);
         }


### PR DESCRIPTION
In order to make Product Page Optimization working, we need this other build setting to be filled. I think it should not interfere with any other usage you had before.